### PR TITLE
added support for unassociated alpha (ExtraSamples value 2)

### DIFF
--- a/tiff.js
+++ b/tiff.js
@@ -614,7 +614,7 @@ TIFFParser.prototype = {
 
 						if (numExtraSamples > 0) {
 							for (var k = 0; k < numExtraSamples; k++) {
-								if (extraSamplesValues[k] === 1) {
+								if (extraSamplesValues[k] === 1 || extraSamplesValues[k] === 2) {
 									opacity = pixelSamples[3 + k] / 256;
 
 									break;


### PR DESCRIPTION
This pull request is not as straightforward as the other one, curious what you think.

From what I can gather from the spec, there are basically two forms of alpha, associated (ExtraSamples value of 1) and unassociated (ExtraSamples value of 2). Associated alpha is premultiplied, and unassociated is not, that being the only technical difference.

So I _think_ for associated alpha, the correct thing to do is to divide R, G and B by alpha, to get rid of the premultiplication. I didn't actually do that in this commit.

For this pull request, I just had it recognize both 1 and 2 as alpha. For my test image which has 2 set, it ends up rendering the image the same way as the GIMP does.
